### PR TITLE
fix: remove gorilla usage in middlewares

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/go-openapi/strfmt v0.21.3
 	github.com/go-openapi/swag v0.21.1
 	github.com/go-openapi/validate v0.22.0
-	github.com/gorilla/mux v1.8.0
 	github.com/mitchellh/mapstructure v1.4.3
 	github.com/newrelic/go-agent/v3 v3.18.2
 	github.com/newrelic/newrelic-opencensus-exporter-go v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -715,7 +715,6 @@ github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
-github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=

--- a/internal/server/reqctx/middleware.go
+++ b/internal/server/reqctx/middleware.go
@@ -3,8 +3,6 @@ package reqctx
 import (
 	"net/http"
 	"strings"
-
-	gorillamux "github.com/gorilla/mux"
 )
 
 // shield header names.
@@ -15,7 +13,7 @@ const (
 	headerRequestID = "X-Request-Id"
 )
 
-func WithRequestCtx() gorillamux.MiddlewareFunc {
+func WithRequestCtx() func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			reqID := strings.TrimSpace(r.Header.Get(headerRequestID))


### PR DESCRIPTION
Some gorilla imports were still present in middlewares. This PR removes those and moves to go-chi completely.